### PR TITLE
alteração da rota destroy

### DIFF
--- a/app/Http/Controllers/InsuredController.php
+++ b/app/Http/Controllers/InsuredController.php
@@ -7,7 +7,6 @@ use App\Services\ApiResponse;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use App\Rules\CpfCnpj;
-use App\Models\PersonalAccessToken;
 
 class InsuredController extends Controller
 {
@@ -224,7 +223,7 @@ class InsuredController extends Controller
 
     /**
 *  @OA\Delete(
-*      path="/api/Insured",
+*      path="/api/Insured/{id}",
 *      summary="Delete a insured",
 *      description="Delete a insured",
 *      tags={"Insured"},

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -5,8 +5,6 @@ namespace App\Http\Controllers;
 use App\Models\User;
 use App\Services\ApiResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
-use App\Http\Middleware\CheckUserPermission;
 
 class UserController extends Controller
 {

--- a/app/Http/Middleware/CheckUserPermission.php
+++ b/app/Http/Middleware/CheckUserPermission.php
@@ -17,7 +17,7 @@ class CheckUserPermission
     public function handle(Request $request, Closure $next): Response
     {
         $userId = auth()->id();
-        //dd("ID DO USUÁRIO:" .$userId);
+        
         $access = app(AccessPermissionService::class)->userHasWildcardPermission($userId);
 
         if (!$access) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,10 +2,7 @@
 
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\InsuredController;
-use App\Http\Controllers\PeriodController;
 use App\Http\Controllers\UserController;
-use App\Http\Controllers\ItemController;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 Route::post('Authentication/login', [AuthController::class, 'login']);

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -165,45 +165,6 @@
                         "bearerAuth": []
                     }
                 ]
-            },
-            "delete": {
-                "tags": [
-                    "Insured"
-                ],
-                "summary": "Delete a insured",
-                "description": "Delete a insured",
-                "operationId": "cb2852a27951a014f285c0a0ac48f4a4",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "description": "ID do segurado",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {}
-                        }
-                    },
-                    "404": {
-                        "description": "insured not found",
-                        "content": {
-                            "application/json": {}
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ]
             }
         },
         "/api/Insured/{id}": {
@@ -312,6 +273,45 @@
                         }
                     }
                 },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "404": {
+                        "description": "insured not found",
+                        "content": {
+                            "application/json": {}
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Insured"
+                ],
+                "summary": "Delete a insured",
+                "description": "Delete a insured",
+                "operationId": "f669e83c21c34155e36cd6073423710b",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID do segurado",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",


### PR DESCRIPTION
<!-- Título curto e descritivo do PR -->
# Alteração da rota destroy 

## Descrição
- **O quê?**  
# Alteração da rota destroy para incluir o id do segurado

- **Por quê?**  
  Estava faltando o id para conseguir deletar o segurado

## Solução Proposta
Explique em alto nível a abordagem adotada para resolver o problema:
1. Item 1 da lógica
2. Item 2 da lógica
3. …

## Como Testar
1. Pré-requisitos:  
   - ex.: `composer install`  
   - ex.: rodar migrations: `php artisan migrate`
2. Passo a passo:  
   - Acesse `route/exemplo`  
   - Faça X e veja Y  
3. Cenários de borda ou casos especiais

## Screenshots (se aplicável)
| Antes | Depois |
|:-----:|:------:|
| ![antes](link) | ![depois](link) |

## Checklist
- [ ] Código com PSR-12 / linters aprovados  
- [ ] Testes unitários/integrados adicionados e passando  
- [ ] Documentação atualizada  
- [ ] Migrações (se houver) testadas em ambiente de desenvolvimento  
- [ ] Não há warnings ou erros no console

## Observações
- Pontos de atenção ou decisões específicas (ex.: performance, segurança, compatibilidade)
- Instruções de rollback (se necessário)
