### PR TITLE
alterar rota delete user e anotações do swagger

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -9,7 +9,7 @@ use Illuminate\Http\Request;
 class AuthController extends Controller
 {
 /**
-*  @OA\POST(
+*  @OA\Post(
 *      path="/api/Authentication/login",
 *      summary="Login",
 *      description="Login",
@@ -64,7 +64,7 @@ class AuthController extends Controller
     }
 
   /**
-*  @OA\DELETE(
+*  @OA\Delete(
 *      path="/api/Authentication/logout",
 *      summary="Revoke the last user token",
 *      description="Revoke the last user token",

--- a/app/Http/Controllers/InsuredController.php
+++ b/app/Http/Controllers/InsuredController.php
@@ -11,7 +11,7 @@ use App\Rules\CpfCnpj;
 class InsuredController extends Controller
 {
     /**
-*  @OA\GET(
+*  @OA\Get(
 *      path="/api/Insured",
 *      summary="Get all insured",
 *      description="Get all insured",
@@ -33,7 +33,7 @@ class InsuredController extends Controller
     }
 
     /**
-*  @OA\POST(
+*  @OA\Post(
 *      path="/api/Insured",
 *      summary="Create a insured",
 *      description="Create a insured",
@@ -94,7 +94,7 @@ class InsuredController extends Controller
     }
 
    /**
-*  @OA\GET(
+*  @OA\Get(
 *      path="/api/Insured/{id}",
 *      summary="Get insured by id",
 *      description="Get insured by id",
@@ -140,7 +140,7 @@ class InsuredController extends Controller
     }
 
     /**
-*  @OA\PUT(
+*  @OA\Put(
 *      path="/api/Insured/{id}",
 *      summary="Update a insured",
 *      description="Update a insured",

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -12,7 +12,7 @@ class UserController extends Controller
     
     
     /**
-*  @OA\GET(
+*  @OA\Get(
 *      path="/api/User",
 *      summary="Get all users",
 *      description="Get all users",
@@ -34,7 +34,7 @@ class UserController extends Controller
     }
 
     /**
-*  @OA\POST(
+*  @OA\Post(
 *      path="/api/User",
 *      summary="Create a user",
 *      description="Create a user",
@@ -85,7 +85,7 @@ class UserController extends Controller
     }
 
     /**
-*  @OA\GET(
+*  @OA\Get(
 *      path="/api/User/{id}",
 *      summary="Get user by id",
 *      description="Get user by id",
@@ -130,7 +130,7 @@ class UserController extends Controller
     }
 
     /**
-*  @OA\PUT(
+*  @OA\Put(
 *      path="/api/User/{id}",
 *      summary="Update a user",
 *      description="Update a user",
@@ -200,9 +200,9 @@ class UserController extends Controller
 
 
 
-        /**
+/**
 *  @OA\Delete(
-*      path="/api/User",
+*      path="/api/User/{id}",
 *      summary="Delete a user",
 *      description="Delete a user",
 *      tags={"User"},

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -410,45 +410,6 @@
                         "bearerAuth": []
                     }
                 ]
-            },
-            "delete": {
-                "tags": [
-                    "User"
-                ],
-                "summary": "Delete a user",
-                "description": "Delete a user",
-                "operationId": "b6efe346218bd422c64fafc73c1f7507",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "description": "ID do usuário",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {}
-                        }
-                    },
-                    "404": {
-                        "description": "user not found",
-                        "content": {
-                            "application/json": {}
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ]
             }
         },
         "/api/User/{id}": {
@@ -552,6 +513,45 @@
                     },
                     "404": {
                         "description": "User not found",
+                        "content": {
+                            "application/json": {}
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Delete a user",
+                "description": "Delete a user",
+                "operationId": "097fac385b5e2c8607f5c08a66ad24ba",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID do usuário",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "404": {
+                        "description": "user not found",
                         "content": {
                             "application/json": {}
                         }


### PR DESCRIPTION
<!-- Título curto e descritivo do PR -->
# Alteração rota delete user e anotações Swagger

## Descrição
- **O quê?**  
  Correção para passar o id do usuário no destroy e padronização de nome no swagger

- **Por quê?**  
  Estava faltando passar o id do usuário na rota do delete do usuário e padronizado nomenclatura Get, Update, Post e Delete no Swagger para não dar nenhum tipo de erro

## Solução Proposta
Explique em alto nível a abordagem adotada para resolver o problema:
1. Item 1 da lógica
2. Item 2 da lógica
3. …

## Como Testar
1. Pré-requisitos:  
   - ex.: `composer install`  
   - ex.: rodar migrations: `php artisan migrate`
2. Passo a passo:  
   - Acesse `route/exemplo`  
   - Faça X e veja Y  
3. Cenários de borda ou casos especiais

## Screenshots (se aplicável)
| Antes | Depois |
|:-----:|:------:|
| ![antes](link) | ![depois](link) |

## Checklist
- [ ] Código com PSR-12 / linters aprovados  
- [ ] Testes unitários/integrados adicionados e passando  
- [ ] Documentação atualizada  
- [ ] Migrações (se houver) testadas em ambiente de desenvolvimento  
- [ ] Não há warnings ou erros no console

## Observações
- Pontos de atenção ou decisões específicas (ex.: performance, segurança, compatibilidade)
- Instruções de rollback (se necessário)
